### PR TITLE
Allow configurable assignPublicIp and platformVersion parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ You _must_ also set the following settings on `c.FargateSpawner` in your `jupyte
 | `task_container_name` | The name of the container in the task definition. | `'jupyerhub-notebook'` |
 | `task_definition_arn` | The family and revision (family:revision) or full ARN of the task definition that runs the notebooks. Typically, this task definition would specify a docker image that builds on one of those from https://github.com/jupyter/docker-stacks. | `'jupyterhub-notebook:7'` |
 | `task_security_groups` | The security group(s) associated with the Fargate tasks. These must allow communication to and from the hub/proxy. More information, such as the ports used, is at https://jupyterhub.readthedocs.io/en/stable/getting-started/networking-basics.html. | `['sg-00026fc201a4e374b']` |
-| `task_subnets` | The subnets associated with the Fargate tasks. | `['subnet-01fc5f15ac710c012']` } |
+| `task_subnets` | The subnets associated with the Fargate tasks. | `['subnet-01fc5f15ac710c012']` |
+| `task_assign_public_ip` | Whether the task's elastic network interface receives a public IP address. | `DISABLED` |
+| `task_platform_version` | The platform version the task should run. | `LATEST` |
 | `notebook_port` | The port the notebook servers listen on. | `8888` |
 | `notebook_scheme` | The scheme used by the hub and proxy to connect to the notebook servers. At the time of writing `'https'` will not work out of the box. However, users do not connect to the the notebook server directly, and does not, typically, allow incoming connections from the public internet. Instead, users connect to the proxy, which can be configured to listen on HTTPS independently of this setting. There is more information on setting up HTTPS for connections to the proxy at https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html. | `'http'` |
 | `notebook_args` | Additional arguments to be passed to `jupyterhub-singleuser` that starts each notebook server. This can be the empty list. | `['--config=notebook_config.py']` |

--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ You _must_ also set the following settings on `c.FargateSpawner` in your `jupyte
 | `task_definition_arn` | The family and revision (family:revision) or full ARN of the task definition that runs the notebooks. Typically, this task definition would specify a docker image that builds on one of those from https://github.com/jupyter/docker-stacks. | `'jupyterhub-notebook:7'` |
 | `task_security_groups` | The security group(s) associated with the Fargate tasks. These must allow communication to and from the hub/proxy. More information, such as the ports used, is at https://jupyterhub.readthedocs.io/en/stable/getting-started/networking-basics.html. | `['sg-00026fc201a4e374b']` |
 | `task_subnets` | The subnets associated with the Fargate tasks. | `['subnet-01fc5f15ac710c012']` |
-| `task_assign_public_ip` | Whether the task's elastic network interface receives a public IP address. | `DISABLED` |
-| `task_platform_version` | The platform version the task should run. | `LATEST` |
 | `notebook_port` | The port the notebook servers listen on. | `8888` |
 | `notebook_scheme` | The scheme used by the hub and proxy to connect to the notebook servers. At the time of writing `'https'` will not work out of the box. However, users do not connect to the the notebook server directly, and does not, typically, allow incoming connections from the public internet. Instead, users connect to the proxy, which can be configured to listen on HTTPS independently of this setting. There is more information on setting up HTTPS for connections to the proxy at https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html. | `'http'` |
 | `notebook_args` | Additional arguments to be passed to `jupyterhub-singleuser` that starts each notebook server. This can be the empty list. | `['--config=notebook_config.py']` |
+
+Following settings are optional:
+
+| Setting | Description | Example |
+| --- | --- | --- |
+| `task_assign_public_ip` | Whether the task's elastic network interface receives a public IP address. | defaults to `DISABLED` |
+| `task_platform_version` | The platform version the task should run. | defaults to `LATEST` |
 
 You must also, either, authenticate using a secret key, in which case you must have the following configuration
 

--- a/fargatespawner/fargatespawner.py
+++ b/fargatespawner/fargatespawner.py
@@ -104,6 +104,8 @@ class FargateSpawner(Spawner):
     task_definition_arn = Unicode(config=True)
     task_security_groups = List(trait=Unicode, config=True)
     task_subnets = List(trait=Unicode, config=True)
+    task_assign_public_ip = Unicode(config=True)
+    task_platform_version = Unicode(config=True)
     notebook_port = Int(config=True)
     notebook_scheme = Unicode(config=True)
     notebook_args = List(trait=Unicode, config=True)
@@ -169,6 +171,7 @@ class FargateSpawner(Spawner):
                 self.task_role_arn,
                 self.task_cluster_name, self.task_container_name, self.task_definition_arn,
                 self.task_security_groups, self.task_subnets,
+                self.task_assign_public_ip, self.task_platform_version,
                 self.cmd + args, self.get_env())
             task_arn = run_response['tasks'][0]['taskArn']
             self.progress_buffer.write({'progress': 1})
@@ -290,6 +293,7 @@ async def _describe_task(logger, aws_endpoint, task_cluster_name, task_arn):
 async def _run_task(logger, aws_endpoint,
                     task_role_arn,
                     task_cluster_name, task_container_name, task_definition_arn, task_security_groups, task_subnets,
+                    task_assign_public_ip, task_platform_version,
                     task_command_and_args, task_env):
     return await _make_ecs_request(logger, aws_endpoint, 'RunTask', {
         'cluster': task_cluster_name,
@@ -311,11 +315,12 @@ async def _run_task(logger, aws_endpoint,
         'launchType': 'FARGATE',
         'networkConfiguration': {
             'awsvpcConfiguration': {
-                'assignPublicIp': 'DISABLED',
+                'assignPublicIp': task_assign_public_ip,
                 'securityGroups': task_security_groups,
                 'subnets': task_subnets,
             },
         },
+        'platformVersion': task_platform_version
     })
 
 

--- a/fargatespawner/fargatespawner.py
+++ b/fargatespawner/fargatespawner.py
@@ -28,6 +28,7 @@ from traitlets.config.configurable import (
 from traitlets import (
     Bool,
     Dict,
+    Enum,
     Instance,
     Int,
     List,
@@ -104,8 +105,8 @@ class FargateSpawner(Spawner):
     task_definition_arn = Unicode(config=True)
     task_security_groups = List(trait=Unicode, config=True)
     task_subnets = List(trait=Unicode, config=True)
-    task_assign_public_ip = Unicode(config=True)
-    task_platform_version = Unicode(config=True)
+    task_assign_public_ip = Enum(["DISABLED", "ENABLED"], "DISABLED", config=True)
+    task_platform_version = Unicode("LATEST", config=True)
     notebook_port = Int(config=True)
     notebook_scheme = Unicode(config=True)
     notebook_args = List(trait=Unicode, config=True)


### PR DESCRIPTION
• Allow to define platformVersion (e.g. 1.4.0 which supports NFS mounts)
• Allow public IP to be assigned to the task in order to get access to external repositories when running in public subnets