### PR TITLE
Pass only Jupyterhub related environment variables to the Fargate task

### DIFF
--- a/fargatespawner/fargatespawner.py
+++ b/fargatespawner/fargatespawner.py
@@ -302,7 +302,7 @@ async def _run_task(logger, aws_endpoint,
                     {
                         'name': name,
                         'value': value,
-                    } for name, value in task_env.items()
+                    } for name, value in task_env.items() if name.startswith('JUPYTERHUB') or name.startswith('JPY')
                 ],
                 'name': task_container_name,
             }],


### PR DESCRIPTION
Don't override PATH, LC_*, etc. which should rather be set by the docker image.