### PR TITLE
(feat) Change interface to allow full customisation of RunTask arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,52 @@ You _must_ also set the following settings on `c.FargateSpawner` in your `jupyte
 | --- | --- | --- |
 | `aws_region` | The AWS region in which the tasks are launched. | `'eu-west-1'` |
 | `aws_ecs_host`  | The hostname of the AWS ECS API. Typically, this is of the form `ecs.<aws-region>.amazonaws.com`. | `'ecs.eu-west-1.amazonaws.com'` |
-| `task_role_arn` | The role the notebook tasks can assume. For example, in order for them to make requests to AWS, such as to use [Jupyter S3](https://github.com/uktrade/jupyters3) with role-based authentication. | `'arn:aws:iam::123456789012:role/notebook-task'` |
-| `task_cluster_name` | The name of the ECS cluster in which the tasks are launched. | `'jupyerhub-notebooks'` |
-| `task_container_name` | The name of the container in the task definition. | `'jupyerhub-notebook'` |
-| `task_definition_arn` | The family and revision (family:revision) or full ARN of the task definition that runs the notebooks. Typically, this task definition would specify a docker image that builds on one of those from https://github.com/jupyter/docker-stacks. | `'jupyterhub-notebook:7'` |
-| `task_security_groups` | The security group(s) associated with the Fargate tasks. These must allow communication to and from the hub/proxy. More information, such as the ports used, is at https://jupyterhub.readthedocs.io/en/stable/getting-started/networking-basics.html. | `['sg-00026fc201a4e374b']` |
-| `task_subnets` | The subnets associated with the Fargate tasks. | `['subnet-01fc5f15ac710c012']` } |
 | `notebook_port` | The port the notebook servers listen on. | `8888` |
 | `notebook_scheme` | The scheme used by the hub and proxy to connect to the notebook servers. At the time of writing `'https'` will not work out of the box. However, users do not connect to the the notebook server directly, and does not, typically, allow incoming connections from the public internet. Instead, users connect to the proxy, which can be configured to listen on HTTPS independently of this setting. There is more information on setting up HTTPS for connections to the proxy at https://jupyterhub.readthedocs.io/en/stable/getting-started/security-basics.html. | `'http'` |
-| `notebook_args` | Additional arguments to be passed to `jupyterhub-singleuser` that starts each notebook server. This can be the empty list. | `['--config=notebook_config.py']` |
+| `get_run_task_args` | _See below_ | _See below_ |
+
+The `get_run_task_args` argument must a callable that takes the spawner instance as a parameter, and returns a dictionary that is passed to the [`RunTask`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html) API call.
+
+```python
+c.FargateSpawner.get_run_task_args = lambda spawner: {
+    'cluster': 'jupyerhub-notebooks',
+    'taskDefinition': 'jupyterhub-notebook:7',
+    'overrides': {
+        'taskRoleArn': 'arn:aws:iam::123456789012:role/notebook-task',
+        'containerOverrides': [{
+            'command': spawner.cmd + [f'--port={spawner.notebook_port}', '--config=notebook_config.py'],
+            'environment': [
+                {
+                    'name': name,
+                    'value': value,
+                } for name, value in spawner.get_env().items()
+            ],
+            'name': 'jupyterhub-notebook',
+        }],
+    },
+    'count': 1,
+    'launchType': 'FARGATE',
+    'networkConfiguration': {
+        'awsvpcConfiguration': {
+            'assignPublicIp': 'DISABLED',
+            'securityGroups': ['sg-00026fc201a4e374b'],
+            'subnets':  ['subnet-01fc5f15ac710c012'],
+        },
+    },
+}
+```
+
+The parts of the return value that probably require change from the above example are:
+
+- **cluster** - The name of the ECS cluster into which the tasks are launched.
+
+- **taskDefinition** - The family:revision or full ARN of the task definition that runs the notebooks. Typically, this task definition would specify a docker image that builds on one from https://github.com/jupyter/docker-stacks.
+
+- **taskRoleArn** - The role the notebook tasks can assume. For example, in order for them to make requests to AWS, such as to use [Jupyter S3](https://github.com/uktrade/jupyters3) with role-based authentication.
+
+- **securityGroups** - The security groups associated with the Fargate task. They must allow communication to and from the hub/proxy. More information, such as the ports used, is at https://jupyterhub.readthedocs.io/en/stable/getting-started/networking-basics.html.
+
+- **subnets** - The list of possible subnets in which the task will start.
 
 You must also, either, authenticate using a secret key, in which case you must have the following configuration
 

--- a/fargatespawner/fargatespawner.py
+++ b/fargatespawner/fargatespawner.py
@@ -42,6 +42,16 @@ AwsCreds = namedtuple('AwsCreds', [
 ])
 
 
+class Callable(TraitType):
+    info_text = 'a callable'
+
+    def validate(self, obj, value):
+        if callable(value):
+            return value
+        else:
+            self.error(obj, value)
+
+
 class Datetime(TraitType):
     klass = datetime.datetime
     default_value = datetime.datetime(1900, 1, 1)
@@ -98,15 +108,11 @@ class FargateSpawner(Spawner):
 
     aws_region = Unicode(config=True)
     aws_ecs_host = Unicode(config=True)
-    task_role_arn = Unicode(config=True)
-    task_cluster_name = Unicode(config=True)
-    task_container_name = Unicode(config=True)
-    task_definition_arn = Unicode(config=True)
-    task_security_groups = List(trait=Unicode, config=True)
-    task_subnets = List(trait=Unicode, config=True)
+
+    get_run_task_args = Callable(config=True)
+
     notebook_port = Int(config=True)
     notebook_scheme = Unicode(config=True)
-    notebook_args = List(trait=Unicode, config=True)
 
     authentication_class = Type(FargateSpawnerAuthentication, config=True)
     authentication = Instance(FargateSpawnerAuthentication)
@@ -116,6 +122,7 @@ class FargateSpawner(Spawner):
         return self.authentication_class(parent=self)
 
     task_arn = Unicode('')
+    task_cluster_arn = Unicode('')
 
     # We mostly are able to call the AWS API to determine status. However, when we yield the
     # event loop to create the task, if there is a poll before the creation is complete,
@@ -132,6 +139,7 @@ class FargateSpawner(Spawner):
 
         # Called when first created: we might have no state from a previous invocation
         self.task_arn = state.get('task_arn', '')
+        self.task_cluster_arn = state.get('task_cluster_arn', '')
 
     def get_state(self):
         ''' Misleading name: the return value of get_state is saved to the database in order
@@ -139,6 +147,7 @@ class FargateSpawner(Spawner):
 
         state = super().get_state()
         state['task_arn'] = self.task_arn
+        state['task_cluster_arn'] = self.task_cluster_arn
 
         return state
 
@@ -151,7 +160,7 @@ class FargateSpawner(Spawner):
         return \
             None if self.calling_run_task else \
             0 if self.task_arn == '' else \
-            None if (await _get_task_status(self.log, self._aws_endpoint(), self.task_cluster_name, self.task_arn)) in ALLOWED_STATUSES else \
+            None if (await _get_task_status(self.log, self._aws_endpoint(), self.task_cluster_arn, self.task_arn)) in ALLOWED_STATUSES else \
             1
 
     async def start(self):
@@ -162,20 +171,15 @@ class FargateSpawner(Spawner):
         progress_buffer.write({'progress': 0.5, 'message': 'Starting server...'})
         try:
             self.calling_run_task = True
-            debug_args = ['--debug'] if self.debug else []
-            args = debug_args + ['--port=' + str(self.notebook_port)] + self.notebook_args
-            run_response = await _run_task(
-                self.log, self._aws_endpoint(),
-                self.task_role_arn,
-                self.task_cluster_name, self.task_container_name, self.task_definition_arn,
-                self.task_security_groups, self.task_subnets,
-                self.cmd + args, self.get_env())
+            run_response = await _run_task(self.log, self._aws_endpoint(), self.get_run_task_args(self))
             task_arn = run_response['tasks'][0]['taskArn']
+            task_cluster_arn = run_response['tasks'][0]['clusterArn']
             progress_buffer.write({'progress': 1})
         finally:
             self.calling_run_task = False
 
         self.task_arn = task_arn
+        self.task_cluster_arn = task_cluster_arn
 
         max_polls = 50
         num_polls = 0
@@ -183,9 +187,9 @@ class FargateSpawner(Spawner):
         while task_ip == '':
             num_polls += 1
             if num_polls >= max_polls:
-                raise Exception('Task {} took too long to find IP address'.format(self.task_arn))
+                raise Exception('Task {} took too long to find IP address'.format(task_arn))
 
-            task_ip = await _get_task_ip(self.log, self._aws_endpoint(), self.task_cluster_name, task_arn)
+            task_ip = await _get_task_ip(self.log, self._aws_endpoint(), task_cluster_arn, task_arn)
             await gen.sleep(1)
             progress_buffer.write({'progress': 1 + num_polls / max_polls})
 
@@ -197,11 +201,11 @@ class FargateSpawner(Spawner):
         while status != 'RUNNING':
             num_polls += 1
             if num_polls >= max_polls:
-                raise Exception('Task {} took too long to become running'.format(self.task_arn))
+                raise Exception('Task {} took too long to become running'.format(task_arn))
 
-            status = await _get_task_status(self.log, self._aws_endpoint(), self.task_cluster_name, task_arn)
+            status = await _get_task_status(self.log, self._aws_endpoint(), task_cluster_arn, task_arn)
             if status not in ALLOWED_STATUSES:
-                raise Exception('Task {} is {}'.format(self.task_arn, status))
+                raise Exception('Task {} is {}'.format(task_arn, status))
 
             await gen.sleep(1)
             progress_buffer.write({'progress': 2 + num_polls / max_polls * 98})
@@ -218,13 +222,14 @@ class FargateSpawner(Spawner):
             return
 
         self.log.debug('Stopping task (%s)...', self.task_arn)
-        await _ensure_stopped_task(self.log, self._aws_endpoint(), self.task_cluster_name, self.task_arn)
+        await _ensure_stopped_task(self.log, self._aws_endpoint(), self.task_cluster_arn, self.task_arn)
         self.log.debug('Stopped task (%s)... (done)', self.task_arn)
 
     def clear_state(self):
         super().clear_state()
         self.log.debug('Clearing state: (%s)', self.task_arn)
         self.task_arn = ''
+        self.task_cluster_arn = ''
         self.progress_buffer = AsyncIteratorBuffer()
 
     async def progress(self):
@@ -242,10 +247,10 @@ class FargateSpawner(Spawner):
 ALLOWED_STATUSES = ('', 'PROVISIONING', 'PENDING', 'RUNNING')
 
 
-async def _ensure_stopped_task(logger, aws_endpoint, task_cluster_name, task_arn):
+async def _ensure_stopped_task(logger, aws_endpoint, task_cluster_arn, task_arn):
     try:
         return await _make_ecs_request(logger, aws_endpoint, 'StopTask', {
-            'cluster': task_cluster_name,
+            'cluster': task_cluster_arn,
             'task': task_arn
         })
     except HTTPError as exception:
@@ -253,8 +258,8 @@ async def _ensure_stopped_task(logger, aws_endpoint, task_cluster_name, task_arn
             raise
 
 
-async def _get_task_ip(logger, aws_endpoint, task_cluster_name, task_arn):
-    described_task = await _describe_task(logger, aws_endpoint, task_cluster_name, task_arn)
+async def _get_task_ip(logger, aws_endpoint, task_cluster_arn, task_arn):
+    described_task = await _describe_task(logger, aws_endpoint, task_cluster_arn, task_arn)
 
     ip_address_attachements = [
         attachment['value']
@@ -265,15 +270,15 @@ async def _get_task_ip(logger, aws_endpoint, task_cluster_name, task_arn):
     return ip_address
 
 
-async def _get_task_status(logger, aws_endpoint, task_cluster_name, task_arn):
-    described_task = await _describe_task(logger, aws_endpoint, task_cluster_name, task_arn)
+async def _get_task_status(logger, aws_endpoint, task_cluster_arn, task_arn):
+    described_task = await _describe_task(logger, aws_endpoint, task_cluster_arn, task_arn)
     status = described_task['lastStatus'] if described_task else ''
     return status
 
 
-async def _describe_task(logger, aws_endpoint, task_cluster_name, task_arn):
+async def _describe_task(logger, aws_endpoint, task_cluster_arn, task_arn):
     described_tasks = await _make_ecs_request(logger, aws_endpoint, 'DescribeTasks', {
-        'cluster': task_cluster_name,
+        'cluster': task_cluster_arn,
         'tasks': [task_arn]
     })
 
@@ -287,36 +292,8 @@ async def _describe_task(logger, aws_endpoint, task_cluster_name, task_arn):
     return task
 
 
-async def _run_task(logger, aws_endpoint,
-                    task_role_arn,
-                    task_cluster_name, task_container_name, task_definition_arn, task_security_groups, task_subnets,
-                    task_command_and_args, task_env):
-    return await _make_ecs_request(logger, aws_endpoint, 'RunTask', {
-        'cluster': task_cluster_name,
-        'taskDefinition': task_definition_arn,
-        'overrides': {
-            'taskRoleArn': task_role_arn,
-            'containerOverrides': [{
-                'command': task_command_and_args,
-                'environment': [
-                    {
-                        'name': name,
-                        'value': value,
-                    } for name, value in task_env.items()
-                ],
-                'name': task_container_name,
-            }],
-        },
-        'count': 1,
-        'launchType': 'FARGATE',
-        'networkConfiguration': {
-            'awsvpcConfiguration': {
-                'assignPublicIp': 'DISABLED',
-                'securityGroups': task_security_groups,
-                'subnets': task_subnets,
-            },
-        },
-    })
+async def _run_task(logger, aws_endpoint, run_task_args):
+    return await _make_ecs_request(logger, aws_endpoint, 'RunTask', run_task_args)
 
 
 async def _make_ecs_request(logger, aws_endpoint, target, dict_data):

--- a/fargatespawner/fargatespawner.py
+++ b/fargatespawner/fargatespawner.py
@@ -159,13 +159,11 @@ class FargateSpawner(Spawner):
 
         self.log.debug('Starting spawner')
 
-        task_port = self.notebook_port
-
         progress_buffer.write({'progress': 0.5, 'message': 'Starting server...'})
         try:
             self.calling_run_task = True
             debug_args = ['--debug'] if self.debug else []
-            args = debug_args + ['--port=' + str(task_port)] + self.notebook_args
+            args = debug_args + ['--port=' + str(self.notebook_port)] + self.notebook_args
             run_response = await _run_task(
                 self.log, self._aws_endpoint(),
                 self.task_role_arn,
@@ -213,7 +211,7 @@ class FargateSpawner(Spawner):
 
         progress_buffer.close()
 
-        return f'{self.notebook_scheme}://{task_ip}:{task_port}'
+        return f'{self.notebook_scheme}://{task_ip}:{self.notebook_port}'
 
     async def stop(self, now=False):
         if self.task_arn == '':


### PR DESCRIPTION
This change offloads some of the behaviour of FargateSpawner to client code.

- It immediately allows setting of tags, platform version, public IP, user input: all of which have current separate PRs.

- It allows the setting of any other existing RunTask options, not yet requested.

- It allows setting of any _future_ RunTask options.

- It is a touch more future friendly to future changed to JupyterHub itself. FargeteSpawner makes slightly fewer calls to its base class, Spawner. If this changed, it is less likely that FargateSpawner would need to change.

- To the potential criticism that this makes the abstraction leaky... it already was leaky: needing to know how security groups and subnets were used etc. Indeed, if every option to RunTask is exposed as a separate option on the spawner, which is then passed through blindly to RunTask, the spawner wouldn't be abstracting anything away. In fact, it would be increasing the burden on the developer since there is more to understand (and so potentially go wrong). I treat this spawner more as a utility than a layer of abstraction, and so this change makes the utility more powerful.

- A reasonable criticism is that this makes the spawner a bit harder in simple cases. However, for me, the above benefits are worth it.

This is a breaking change. Existing users can pin (and I would argue, should have pinned) to a previous version to keep the same interface. The version format hints at SemVer, and which explicitly allows any pre 1.0.0 change to be breaking.